### PR TITLE
Increase the number of repositories returned in projects

### DIFF
--- a/apps/github/github.rb
+++ b/apps/github/github.rb
@@ -58,9 +58,9 @@ module Github
 
     def projects_url
       if payload.overlay and org = payload.overlay.org
-        api_url("orgs/#{org}/repos")
+        api_url("orgs/#{org}/repos?per_page=200")
       else
-        api_url('user/repos')
+        api_url('user/repos?per_page=200')
       end
     end
 


### PR DESCRIPTION
With organizations that have over 30 repos it can be impossible to create tickets as not all repositories are returned.

Increasing the amount of results returned is an interim solution, which may get unwieldy, but that can be solved by adding a filter box or something into the UI later. For now this should help a large number of cases.